### PR TITLE
Backup restore fix

### DIFF
--- a/Tasks/RestoreSqlDatabaseToSqlDatabase/RestoreSqlDatabaseToSqlDatabase.ps1
+++ b/Tasks/RestoreSqlDatabaseToSqlDatabase/RestoreSqlDatabaseToSqlDatabase.ps1
@@ -44,7 +44,7 @@ try {
     Write-VstsTaskVerbose -Message "[Azure Call] Azure SQL Database details got for source $SourceDatabaseName :"
     Write-VstsTaskVerbose -Message ($sourceDatabase | Format-List | Out-String)
 
-    $date = (Get-Date).AddMinutes(-$PointInTimeWindow)
+    $date = (Get-Date).AddMinutes(-($PointInTimeWindow -as [int]))
 
     if ([string]::IsNullOrEmpty($sourceDatabase.ElasticPoolName)) {
         Write-VstsTaskVerbose -Message "[Azure Call] Restoring Azure SQL Database $SourceDatabaseName to $TargetDatabaseName (Edition $($sourceDatabase.Edition) $($sourceDatabase.CurrentServiceObjectiveName))"

--- a/Tasks/RestoreSqlDatabaseToSqlDatabase/RestoreSqlDatabaseToSqlDatabase.ps1
+++ b/Tasks/RestoreSqlDatabaseToSqlDatabase/RestoreSqlDatabaseToSqlDatabase.ps1
@@ -8,6 +8,7 @@ try {
     $ServerName = Get-VstsInput -Name ServerName -Require
     $SourceDatabaseName = Get-VstsInput -Name SourceDatabaseName -Require
     $TargetDatabaseName = Get-VstsInput -Name TargetDatabaseName -Require
+    $PointInTimeWindow = Get-VstsInput -Name PointInTimeWindow -Require
 
     # Initialize Azure.
     Import-Module $PSScriptRoot\ps_modules\VstsAzureHelpers
@@ -43,7 +44,7 @@ try {
     Write-VstsTaskVerbose -Message "[Azure Call] Azure SQL Database details got for source $SourceDatabaseName :"
     Write-VstsTaskVerbose -Message ($sourceDatabase | Format-List | Out-String)
 
-    $date = (Get-Date).AddMinutes(-1)
+    $date = (Get-Date).AddMinutes(-$PointInTimeWindow)
 
     if ([string]::IsNullOrEmpty($sourceDatabase.ElasticPoolName)) {
         Write-VstsTaskVerbose -Message "[Azure Call] Restoring Azure SQL Database $SourceDatabaseName to $TargetDatabaseName (Edition $($sourceDatabase.Edition) $($sourceDatabase.CurrentServiceObjectiveName))"

--- a/Tasks/RestoreSqlDatabaseToSqlDatabase/task.json
+++ b/Tasks/RestoreSqlDatabaseToSqlDatabase/task.json
@@ -52,6 +52,18 @@
             "defaultValue": "",
             "required": true,
             "helpMarkDown": "Name of the target Azure SQL Database. If exists, will be deleted prior to restore!"
+        },
+        {
+            "name": "PointInTimeWindow",
+            "type": "string",
+            "label": "Point In Time Window",
+            "defaultValue": "6",
+            "required": true,
+            "helpMarkDown": "How many minutes into the past to look for a backup to restore from.",
+            "validation": { 
+                  "expression": "isMatch(value,'^\d+$','IgnoreCase')",
+                  "message": "Must be an integer."
+              }
         }
     ],
     "sourceDefinitions": [


### PR DESCRIPTION
Updated the SQL Backup restore task to work with a configurable point in time window. This should resolve #44 as we are experiencing it too now. I can confirm that in our instance the most recent backup has changed at some point to be only at least 6 minutes old and this task is now failing 100% of the time for us.